### PR TITLE
fix: remove prepare scripts that bypass --ignore-scripts in CI

### DIFF
--- a/extensions/hexcore-capstone/package.json
+++ b/extensions/hexcore-capstone/package.json
@@ -19,8 +19,7 @@
     "prebuild": "prebuildify --napi --strip",
     "prebuild:all": "prebuildify-cross -i centos7-devtoolset7 -i alpine -i linux-armv7 -i linux-arm64",
     "test": "node test/test.js",
-    "clean": "node-gyp clean",
-    "prepare": "npm run build"
+    "clean": "node-gyp clean"
   },
   "keywords": [
     "capstone",

--- a/extensions/hexcore-unicorn/package.json
+++ b/extensions/hexcore-unicorn/package.json
@@ -19,8 +19,7 @@
     "prebuild": "prebuildify --napi --strip",
     "prebuild:all": "prebuildify-cross -i centos7-devtoolset7 -i alpine -i linux-armv7 -i linux-arm64",
     "test": "node test/test.js",
-    "clean": "node-gyp clean",
-    "prepare": "npm run build"
+    "clean": "node-gyp clean"
   },
   "keywords": [
     "unicorn",


### PR DESCRIPTION
## Summary
- Removed "prepare": "npm run build" from hexcore-capstone and hexcore-unicorn package.json
- This script triggered node-gyp rebuild during npm ci --ignore-scripts in CI because npm treats prepare specially for file: dependencies, bypassing --ignore-scripts
- hexcore-llvm-mc already lacked a prepare script, which is why it was the only native engine that built successfully

## Test plan
- [ ] Run the HexCore Build Installer workflow on Windows and verify the "Compile HexCore Extensions" step no longer fails on hexcore-capstone/unicorn
- [ ] Verify the "Fetch HexCore Native Prebuilds" step still downloads prebuilds correctly via prebuild-install
- [ ] Confirm npm run build still works manually for local development